### PR TITLE
Fixed detail-search according to googles latest changes

### DIFF
--- a/src/GooglePlaces.php
+++ b/src/GooglePlaces.php
@@ -184,9 +184,9 @@ class GooglePlaces
 					break;
 
 				case 'details':
-					if (!isset($parameters['reference']))
+					if(!(isset($parameters['reference']) ^ isset($parameters['placeid'])))
 					{
-						throw new \Exception('You must specify a reference before calling details().');
+						throw new \Exception('You must specify either a placeid or a reference (but not both) before calling details().');						
 					}
 
 					if (isset($parameters['rankby']))


### PR DESCRIPTION
Google recently changed the behaviour for the Places API, now you must specify either a reference or a placeid. This fix checks for either one of them.

https://developers.google.com/places/documentation/details#PlaceDetailsRequests
