### PR TITLE
Remove SSL Verify on Windows

### DIFF
--- a/src/GooglePlacesClient.php
+++ b/src/GooglePlacesClient.php
@@ -17,6 +17,11 @@ class GooglePlacesClient
 
         curl_setopt_array($curl, $options);
 
+        // Add certificate for Windows
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
+        }
+
         $response = curl_exec($curl);
 
         if ($error = curl_error($curl))


### PR DESCRIPTION
Avoid error CURL Error: SSL certificate problem: unable to get local issuer certificate on windows whitout ssl